### PR TITLE
Use https instead of git:// for source url

### DIFF
--- a/language-c99.cabal
+++ b/language-c99.cabal
@@ -30,7 +30,7 @@ cabal-version:       >=1.10
 
 source-repository head
   type:     git
-  location: git://github.com:fdedden/language-c99.git
+  location: https://github.com/fdedden/language-c99.git
 
 library
   exposed-modules:      Language.C99


### PR DESCRIPTION
`git://` is no longer supported.